### PR TITLE
fix typo in bonus type enum

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ declare module 'influence-utils' {
 
   export const enum BonusType {
     Yield = 'yield',
-    Volantile = 'volantile',
+    Volantile = 'volatile',
     Metal = 'metal',
     Organic = 'organic',
     RareEarth = 'rareearth',


### PR DESCRIPTION
Enum value for 'volatile' had one letter too much ...